### PR TITLE
Fix multi-process deadlock in case another process crashes while holding the multi-process file mutex

### DIFF
--- a/src/NLog/Internal/FileAppenders/MutexMultiProcessFileAppender.cs
+++ b/src/NLog/Internal/FileAppenders/MutexMultiProcessFileAppender.cs
@@ -102,7 +102,17 @@ namespace NLog.Internal.FileAppenders
 
             try
             {
-                this.mutex.WaitOne();
+                try
+                {
+                    this.mutex.WaitOne();
+                }
+                catch(AbandonedMutexException)
+                {
+                    // Ignore - mutex is owned, though (acc.to documentation  
+                    // of AbandonedMutexException). Presumably another process
+                    // writing to the same log was killed in the middle 
+                    // of this try/finally block.
+                }
                 this.file.Seek(0, SeekOrigin.End);
                 this.file.Write(bytes, 0, bytes.Length);
                 this.file.Flush();

--- a/src/NLog/Internal/FileAppenders/MutexMultiProcessFileAppender.cs
+++ b/src/NLog/Internal/FileAppenders/MutexMultiProcessFileAppender.cs
@@ -100,9 +100,9 @@ namespace NLog.Internal.FileAppenders
                 return;
             }
 
-            this.mutex.WaitOne();
             try
             {
+                this.mutex.WaitOne();
                 this.file.Seek(0, SeekOrigin.End);
                 this.file.Write(bytes, 0, bytes.Length);
                 this.file.Flush();


### PR DESCRIPTION
Basically, if you have 2 processes writing to the same log file, and one is killed while it is writing a logging message, then the other process will hang.

I observed this behavior in a program that had many worker processes logging to the same file but could terminate any of them at any moment. On a large cluster, a small number of these processes non-deterministically sometimes got stuck, and a process dump showed that they were indeed waiting in MutexMultiProcessFileAppender.Write, in the mutex.WaitOne() line.

Reason:
Look at the <a href="https://github.com/jkowalski/NLog/blob/master/src/NLog/Internal/FileAppenders/MutexMultiProcessFileAppender.cs#L96-115">source</a>.

A process enters WaitOne(), then enters Write() and then someone terminates it.
Another process enters WaitOne() and immediately gets an AbandonedMutexException(), though the mutex is still entered but not released, as WaitOne() is not within the try..finally.

NLog supposedly recreates the appender, and the next time WaitOne() succeeds, bumping the mutex's entry count to 2, but the subsequent ReleaseMutex() only decreases the entry count from 2 to 1. So it remains forever entered.

The patch is really simple - move WaitOne() into try..finally.
