### PR TITLE
Added an additional config file candidate

### DIFF
--- a/src/NLog/LogFactory.cs
+++ b/src/NLog/LogFactory.cs
@@ -660,6 +660,9 @@ namespace NLog
                 yield return Path.ChangeExtension(cf, ".nlog");
             }
 
+            string configurationFileName = Path.GetFileName(cf);
+            yield return Path.Combine(AppDomain.CurrentDomain.SetupInformation.PrivateBinPath, "NLog.config");
+
             // get path to NLog.dll.nlog only if the assembly is not in the GAC
             var nlogAssembly = typeof(LogFactory).Assembly;
             if (!nlogAssembly.GlobalAssemblyCache)


### PR DESCRIPTION
Fixes the issue when you try and deploy a web application and the config file is in the Bin directory (like an ASP.NET MVC 3 application).
